### PR TITLE
为DragonOS编译工具链

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /linux-*/
 /isl-*/
 /build/
+*.tgz

--- a/dragonos-config-stage1.mak
+++ b/dragonos-config-stage1.mak
@@ -1,0 +1,88 @@
+#
+# config.mak.dist - sample musl-cross-make configuration
+#
+# Copy to config.mak and edit as desired.
+#
+
+# There is no default TARGET; you must select one here or on the make
+# command line. Some examples:
+
+# TARGET = i486-linux-musl
+TARGET = x86_64-linux-musl
+# TARGET = arm-linux-musleabi
+# TARGET = arm-linux-musleabihf
+# TARGET = sh2eb-linux-muslfdpic
+# ...
+
+# By default, cross compilers are installed to ./output under the top-level
+# musl-cross-make directory and can later be moved wherever you want them.
+# To install directly to a specific location, set it here. Multiple targets
+# can safely be installed in the same location. Some examples:
+
+# OUTPUT = /opt/cross
+# OUTPUT = /usr/local
+
+# By default, latest supported release versions of musl and the toolchain
+# components are used. You can override those here, but the version selected
+# must be supported (under hashes/ and patches/) to work. For musl, you
+# can use "git-refname" (e.g. git-master) instead of a release. Setting a
+# blank version for gmp, mpc, mpfr and isl will suppress download and
+# in-tree build of these libraries and instead depend on pre-installed
+# libraries when available (isl is optional and not set by default).
+# Setting a blank version for linux will suppress installation of kernel
+# headers, which are not needed unless compiling programs that use them.
+
+# BINUTILS_VER = 2.25.1
+# GCC_VER = 5.2.0
+# MUSL_VER = git-master
+# GMP_VER =
+# MPC_VER =
+# MPFR_VER =
+# ISL_VER =
+# LINUX_VER =
+
+# By default source archives are downloaded with wget. curl is also an option.
+
+# DL_CMD = wget -c -O
+# DL_CMD = curl -C - -L -o
+
+# Check sha-1 hashes of downloaded source archives. On gnu systems this is
+# usually done with sha1sum.
+
+# SHA1_CMD = sha1sum -c
+# SHA1_CMD = sha1 -c
+# SHA1_CMD = shasum -a 1 -c
+
+# Something like the following can be used to produce a static-linked
+# toolchain that's deployable to any system with matching arch, using
+# an existing musl-targeted cross compiler. This only works if the
+# system you build on can natively (or via binfmt_misc and qemu) run
+# binaries produced by the existing toolchain (in this example, i486).
+
+# COMMON_CONFIG += CC="x86_64-linux-musl-gcc -static --static" CXX="x86_64-linux-musl-g++ -static --static"
+
+# Recommended options for smaller build for deploying binaries:
+
+# COMMON_CONFIG += CFLAGS="-g0 -Os" CXXFLAGS="-g0 -Os" LDFLAGS="-s"
+
+# Options you can add for faster/simpler build at the expense of features:
+
+# COMMON_CONFIG += --disable-nls
+# GCC_CONFIG += --disable-libquadmath --disable-decimal-float
+# GCC_CONFIG += --disable-libitm
+# GCC_CONFIG += --disable-fixed-point
+# GCC_CONFIG += --disable-lto
+
+# By default C and C++ are the only languages enabled, and these are
+# the only ones tested and known to be supported. You can uncomment the
+# following and add other languages if you want to try getting them to
+# work too.
+
+# GCC_CONFIG += --enable-languages=c,c++
+
+
+# You can keep the local build path out of your toolchain binaries and
+# target libraries with the following, but then gdb needs to be told
+# where to look for source files.
+
+# COMMON_CONFIG += --with-debug-prefix-map=$(CURDIR)=

--- a/dragonos-config-stage2.mak
+++ b/dragonos-config-stage2.mak
@@ -1,0 +1,88 @@
+#
+# config.mak.dist - sample musl-cross-make configuration
+#
+# Copy to config.mak and edit as desired.
+#
+
+# There is no default TARGET; you must select one here or on the make
+# command line. Some examples:
+
+# TARGET = i486-linux-musl
+TARGET = x86_64-linux-musl
+# TARGET = arm-linux-musleabi
+# TARGET = arm-linux-musleabihf
+# TARGET = sh2eb-linux-muslfdpic
+# ...
+
+# By default, cross compilers are installed to ./output under the top-level
+# musl-cross-make directory and can later be moved wherever you want them.
+# To install directly to a specific location, set it here. Multiple targets
+# can safely be installed in the same location. Some examples:
+
+# OUTPUT = /opt/cross
+# OUTPUT = /usr/local
+
+# By default, latest supported release versions of musl and the toolchain
+# components are used. You can override those here, but the version selected
+# must be supported (under hashes/ and patches/) to work. For musl, you
+# can use "git-refname" (e.g. git-master) instead of a release. Setting a
+# blank version for gmp, mpc, mpfr and isl will suppress download and
+# in-tree build of these libraries and instead depend on pre-installed
+# libraries when available (isl is optional and not set by default).
+# Setting a blank version for linux will suppress installation of kernel
+# headers, which are not needed unless compiling programs that use them.
+
+# BINUTILS_VER = 2.25.1
+# GCC_VER = 5.2.0
+# MUSL_VER = git-master
+# GMP_VER =
+# MPC_VER =
+# MPFR_VER =
+# ISL_VER =
+# LINUX_VER =
+
+# By default source archives are downloaded with wget. curl is also an option.
+
+# DL_CMD = wget -c -O
+# DL_CMD = curl -C - -L -o
+
+# Check sha-1 hashes of downloaded source archives. On gnu systems this is
+# usually done with sha1sum.
+
+# SHA1_CMD = sha1sum -c
+# SHA1_CMD = sha1 -c
+# SHA1_CMD = shasum -a 1 -c
+
+# Something like the following can be used to produce a static-linked
+# toolchain that's deployable to any system with matching arch, using
+# an existing musl-targeted cross compiler. This only works if the
+# system you build on can natively (or via binfmt_misc and qemu) run
+# binaries produced by the existing toolchain (in this example, i486).
+
+COMMON_CONFIG += CC="x86_64-linux-musl-gcc -static --static" CXX="x86_64-linux-musl-g++ -static --static"
+
+# Recommended options for smaller build for deploying binaries:
+
+# COMMON_CONFIG += CFLAGS="-g0 -Os" CXXFLAGS="-g0 -Os" LDFLAGS="-s"
+
+# Options you can add for faster/simpler build at the expense of features:
+
+# COMMON_CONFIG += --disable-nls
+# GCC_CONFIG += --disable-libquadmath --disable-decimal-float
+# GCC_CONFIG += --disable-libitm
+# GCC_CONFIG += --disable-fixed-point
+# GCC_CONFIG += --disable-lto
+
+# By default C and C++ are the only languages enabled, and these are
+# the only ones tested and known to be supported. You can uncomment the
+# following and add other languages if you want to try getting them to
+# work too.
+
+# GCC_CONFIG += --enable-languages=c,c++
+
+
+# You can keep the local build path out of your toolchain binaries and
+# target libraries with the following, but then gdb needs to be told
+# where to look for source files.
+
+# COMMON_CONFIG += --with-debug-prefix-map=$(CURDIR)=

--- a/dragonos.sh
+++ b/dragonos.sh
@@ -1,0 +1,52 @@
+
+install_musl_cross() {
+    # Install musl-cross-make
+    echo "Installing musl-cross-make..."
+    mkdir -p $HOME/opt/cross/x86_64-linux-musl-cross || exit 1
+
+    cp ./dragonos-config-stage1.mak ./config.mak || exit 1
+
+    make clean || exit 1
+    make -j $(nproc) || exit 1
+    make install || exit 1
+    mv ./output/* $HOME/opt/cross/x86_64-linux-musl-cross || exit 1
+
+    # Add musl-cross-make to PATH
+    echo "export PATH=\"\$PATH:$HOME/opt/cross/x86_64-linux-musl-cross/bin\"" >> $HOME/.bashrc || exit 1
+    echo "export PATH=\"\$PATH:$HOME/opt/cross/x86_64-linux-musl-cross/bin\"" >> $HOME/.zshrc || exit 1
+    source $HOME/.bashrc || exit 1
+    source $HOME/.zshrc || exit 1
+}
+
+build_stage2(){
+    echo "Building stage 2..."
+    cp ./dragonos-config-stage2.mak ./config.mak || exit 1
+    make clean || exit 1
+    make -j $(nproc) || exit 1
+    make install || exit 1
+}
+
+# Check if the toolchain is installed
+
+__TOOLCHAIN_INSTALLED=1
+# Check if x86_64-linux-musl-gcc and x86_64-linux-musl-g++ are installed
+if ! command -v x86_64-linux-musl-gcc &> /dev/null
+then
+    echo "x86_64-linux-musl-gcc could not be found."
+    __TOOLCHAIN_INSTALLED=0
+fi
+
+if ! command -v x86_64-linux-musl-g++ &> /dev/null
+then
+    echo "x86_64-linux-musl-g++ could not be found"
+    __TOOLCHAIN_INSTALLED=0
+fi
+
+# Check if the toolchain is installed
+if [ $__TOOLCHAIN_INSTALLED -eq 0 ]
+then
+    install_musl_cross || exit 1
+fi
+
+build_stage2 || exit 1
+


### PR DESCRIPTION
为DragonOS编译工具链,分为2阶段:
1. stage1: 使用了动态链接库的musl-gcc
2. stage2: 使用stage1的编译器,构建纯静态链接的musl-gcc,这个stage2的编译器能够在linux上面运行,也能在DragonOS上运行

使用`bash dragonos.sh`即可启动编译。